### PR TITLE
Error when passing geography objects to stored procs

### DIFF
--- a/Insight.Tests/Insight.Tests.csproj
+++ b/Insight.Tests/Insight.Tests.csproj
@@ -37,6 +37,10 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.SqlServer.Types, Version=10.0.0.0, Culture=neutral, PublicKeyToken=89845dcd8080cc91, processorArchitecture=MSIL">
+      <Private>True</Private>
+      <HintPath>..\packages\Microsoft.SqlServer.Types.10.50.1600.1\lib\Net20\Microsoft.SqlServer.Types.dll</HintPath>
+    </Reference>
     <Reference Include="MiniProfiler">
       <HintPath>..\packages\MiniProfiler.2.0.1\lib\net40\MiniProfiler.dll</HintPath>
     </Reference>

--- a/Insight.Tests/packages.config
+++ b/Insight.Tests/packages.config
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="Microsoft.SqlServer.Types" version="10.50.1600.1" targetFramework="net45" />
   <package id="MiniProfiler" version="2.0.1" />
   <package id="Moq" version="4.0.10827" />
   <package id="NUnit" version="2.5.10.11092" />


### PR DESCRIPTION
Hi,
When trying to pass `SqlGeography` parameters to stored procs with Insight, it fails to create correct `SqlParameter` objects. The error reported is "Operand type clash: sql_variant is incompatible with geography".

I've created a failing test for this, but since there is a new NuGet package and a few scattered changes, I am sumbitting it as a pull request instead of an issue.
