### PR TITLE
roots was empty so the call to roots.Single throws InvalidOperationException

### DIFF
--- a/Insight.Database/Structure/SingleChildMapper.cs
+++ b/Insight.Database/Structure/SingleChildMapper.cs
@@ -39,7 +39,7 @@ namespace Insight.Database.Structure
 		/// <param name="children">The list of children.</param>
 		public void MapChildren(IEnumerable<TParent> roots, IEnumerable<TChild> children)
 		{
-			var single = roots.Single();
+			var single = roots.SingleOrDefault();
 
 			if (single == null)
 			{


### PR DESCRIPTION
I am using  the attribute [Recordset(1, typeof(Detail), IsChild = true)]
on a sp that contains two queries (first master, second detail).
I am working with autoimplemented interfaces.

One of my tests tries to get a non-existing master-detail from the database and throws possible to this mapchildren function.
