### PR TITLE
Fix InvalidOperationException if entity has a lot of fields (128+)

### DIFF
--- a/Insight.Database/CodeGenerator/TypeHelper.cs
+++ b/Insight.Database/CodeGenerator/TypeHelper.cs
@@ -126,7 +126,7 @@ namespace Insight.Database.CodeGenerator
 			if (type.IsGenericParameter || type.IsValueType)
 			{
 				var returnValue = mIL.DeclareLocal(type);
-				mIL.Emit(OpCodes.Ldloca_S, returnValue);
+				mIL.Emit(returnValue.LocalIndex < 256 ? OpCodes.Ldloca_S : OpCodes.Ldloca, returnValue);
 				mIL.Emit(OpCodes.Initobj, type);
 				mIL.Emit(OpCodes.Ldloc, returnValue);
 			}


### PR DESCRIPTION
Solution throws exception if entity has a lot of fields (128+).
We have encountered this behavior in our internal solution.

To reproduce issue you should have a class with 130 fields and a query returning these 130 fields.
If either one is lower the issue didn't be reproduce.

The issue related to short form of IL OpCode, which can handle only 255 parameters maximum.
The fix is smart enough to use short form of IL OpCode if number of local parameters is small and a full form if it is not.

Short form:
https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.ldloca_s(v=vs.110).aspx

Full form:
https://msdn.microsoft.com/en-us/library/system.reflection.emit.opcodes.ldloca(v=vs.110).aspx