### PR TITLE
Issue #215

### DIFF
--- a/Insight.Database/CodeGenerator/ObjectListDbDataReader.cs
+++ b/Insight.Database/CodeGenerator/ObjectListDbDataReader.cs
@@ -116,6 +116,10 @@ namespace Insight.Database.CodeGenerator
 				if (_current == null && !_objectReader.IsAtomicType)
 					throw new InvalidOperationException("Cannot send a list of objects to a table-valued parameter when the list contains a null value");
 			}
+			else
+			{
+				_enumerator.Reset();
+			}
 
 			return hasItems;
 		}


### PR DESCRIPTION
Hi Jon,

Sorry I only had time to work on the bug that I recently reported.

I have fixed the bug that I reported on issue #215.  If you invoke an InsertListAsync for example and the stored proc doesn't execute before the command timeout, and you have the RetryStrategy wired up -- the second attempt to InsertListAsync will pass an empty user-defined table type arg.  Resetting the _enumerator once we have detected that it has reached the end is desired and fixed the bug...

Thank you,
David Pine