### PR TITLE
Support auto mapping to plain ID fields, e.g. InvoiceLine.Invoice_ID -> Invoice.ID.

### DIFF
--- a/Insight.Database/Structure/ChildMapperHelper.cs
+++ b/Insight.Database/Structure/ChildMapperHelper.cs
@@ -243,19 +243,37 @@ namespace Insight.Database.Structure
         /// <returns>A matching IDAccessor or null.</returns>
         private static IDAccessor InferParentIDAccessorFromParentClass(Type type, Type parentType)
         {
+            IDAccessor idAccessor = null;
+
             if (parentType == null)
                 return null;
 
+            // Determine the PK of the parent so we can try to translate it to the child            
             var parentIDAccessor = FindIDAccessor<RecordIdAttribute>(parentType, null, DefaultIDField);
             if (parentIDAccessor == null)
                 return null;
 
-            // don't match an "ID" field of the parent to the "ID" field on this type
             var parentIDNames = parentIDAccessor.MemberNames.ToList();
-            if (parentIDNames.Count() == 1 && parentIDNames.First().IsIEqualTo(DefaultIDField))
-                return null;
 
-            return FindIDAccessorByNameList(type, parentIDNames, false);
+            // If the parent's PK is just ID, we can't say 
+            // InvoiceLine.ID => Invoice.ID, but InvoiceLine.Invoice_ID => Invoice.ID makes sense
+            if (parentIDNames.Count() == 1 && parentIDNames.First().IsIEqualTo(DefaultIDField))
+            {
+                parentIDNames[0] = parentType.Name + '_' + DefaultIDField;
+                idAccessor = FindIDAccessorByNameList(type, parentIDNames, false);
+
+                if (idAccessor == null)
+                {
+                    // Now try InvoiceLine.InvoiceID => Invoice.ID
+                    parentIDNames[0] = parentType.Name + DefaultIDField;
+                    idAccessor = FindIDAccessorByNameList(type, parentIDNames, false);    
+                }
+
+            }
+            else
+                idAccessor = FindIDAccessorByNameList(type, parentIDNames, false);
+
+            return idAccessor;
         }
-	}
+    }
 }

--- a/Insight.Tests/GroupByTests.cs
+++ b/Insight.Tests/GroupByTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ChildMappingTests =Insight.Tests.StructureTest_ChildMappingHelperUnitTests;
 
 namespace Insight.Tests
 {
@@ -357,6 +358,35 @@ namespace Insight.Tests
 				Assert.AreEqual(1, parent.Children[0].ParentKey);
 				Assert.AreEqual(30, parent.Children[0].ChildKey);
 			}
+
+			/// <summary>
+			/// Detecting Child's parent id by looking at Parent's ID
+			/// Handle InvoiceLine.Invoice_ID => Invoice.ID
+			/// aka Glass.BeerId ->Beer.Id
+			/// New Functionality (see issue 238 in root repo) 
+			/// </summary>
+			[Test]
+			public void List_MappingOfParentID_ByParentPK_NakedId()
+			{
+				var beer = Connection().QuerySql(
+								"SELECT ID=1, Int2=10; " +
+								"SELECT ID=30, Beer238_ID=1, Value=40" + " UNION " +
+								"SELECT ID=31, Beer238_ID=1, Value=41"
+								, null,
+								Query.Returns(Some<ChildMappingTests.TestClasses.Beer238>.Records)
+								.ThenChildren(Some<ChildMappingTests.TestClasses.Glass238b>.Records))
+								.First();
+
+				Assert.AreEqual(1, beer.ID = 1);
+				Assert.AreEqual(2, beer.GlassesB.Count);
+				Assert.IsNull(beer.GlassesA);
+				Assert.AreEqual(2, beer.GlassesB.Count);
+				Assert.AreEqual(1, beer.GlassesB[0].Beer238_ID);
+				Assert.AreEqual(1, beer.GlassesB[1].Beer238_ID);
+				Assert.AreEqual(40, beer.GlassesB[0].Value);
+				Assert.AreEqual(41, beer.GlassesB[1].Value);
+			}
+
 		}
 		#endregion
 

--- a/Insight.Tests/StructureTests.cs
+++ b/Insight.Tests/StructureTests.cs
@@ -343,6 +343,31 @@ namespace Insight.Tests
 			Assert.AreEqual("Invoice_id", result.ElementAt(0));
 		}
 
+		/// <summary>
+		/// Issue 238: Support myClass.BeerId ->Beer.ID
+		/// </summary>
+		[Test]
+		public void GetParentIDAccessor_WhenPKIsJustId()
+		{
+			var result = ChildMapperTestingHelper.FindParentIDAccessor(typeof(TestClasses.Glass238a), null, typeof(TestClasses.Beer238));
+
+			Assert.AreEqual(1, result.Count());
+			Assert.AreEqual("Beer238ID", result.ElementAt(0));
+		}
+
+		/// <summary>
+        /// Issue 238: Support myClass.BeerId ->Beer.ID
+        /// </summary>
+		[Test]
+		public void GetParentIDAccessor_WhenPKIsJustId_Underscored()
+		{
+			var result = ChildMapperTestingHelper.FindParentIDAccessor(typeof(TestClasses.Glass238b), null, typeof(TestClasses.Beer238));
+
+			Assert.AreEqual(1, result.Count());
+			Assert.AreEqual("Beer238_ID", result.ElementAt(0));
+		}
+
+
 		// throws System.InvalidOperationException 'Sequence contains more than one matching element'
 		// This was barfing on   public int Paid as it end with ID			 
 		/// It should first try to match to [ClassName]ID aka  public int ClassWithSuffixedId;  
@@ -642,6 +667,26 @@ namespace Insight.Tests
 				public int ParentId;
 				public ChildWithGenericNames ChildWithGenericNames;
 				public string Name;
+			}
+
+			public class Beer238
+			{
+				public int ID;
+				public IList<Glass238a> GlassesA;
+				public IList<Glass238b> GlassesB;
+			}
+
+			public class Glass238a
+			{
+				public int ID;
+				public int Beer238ID;
+			}
+
+			public class Glass238b
+			{
+				public int ID;
+				public int Beer238_ID;
+				public int Value;
 			}
 
 		}


### PR DESCRIPTION
Code and tests to address issue #238.  

Supports auto mapping to plain ID fields.  E.g. auto mapping InvoiceLine.Invoice_ID -> Invoice.ID 

Or mapping MyClass.BeerId -> Beer.ID