### PR TITLE
Enabled Insight to implement protected abstract methods.

### DIFF
--- a/Insight.Database/CodeGenerator/InterfaceGenerator.cs
+++ b/Insight.Database/CodeGenerator/InterfaceGenerator.cs
@@ -242,7 +242,7 @@ namespace Insight.Database.CodeGenerator
 			}
 			else
 			{
-				return type.GetMethods(BindingFlags.Public | BindingFlags.Instance | BindingFlags.InvokeMethod)
+				return type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.InvokeMethod)
 					.Where(m => m.IsAbstract);
 			}
 		}

--- a/Insight.Tests/InterfaceTests.cs
+++ b/Insight.Tests/InterfaceTests.cs
@@ -953,6 +953,15 @@ namespace Insight.Tests
 		}
 	}
 
+	public abstract class AbstractClassWithProtectedMethod
+	{
+		public string PublicMethod()
+		{ return AbstractMethod(); }
+
+		[Sql("SELECT 'abstract'")]
+		protected abstract string AbstractMethod();
+	}
+
 	[TestFixture]
 	public class AbstractClassTests : BaseTest
 	{
@@ -1013,6 +1022,15 @@ namespace Insight.Tests
 			var connection = Connection();
 
 			Assert.Throws<InvalidOperationException>(() => connection.AsParallel<AbstractClassOfDbConnectionWrapper>());
+		}
+
+		[Test]
+		public void ProtectedAbstractMethodIsImplemented()
+		{
+			var connection = Connection();
+
+			var i = connection.As<AbstractClassWithProtectedMethod>();
+			Assert.AreEqual("abstract", i.PublicMethod());
 		}
 	}
 	#endregion


### PR DESCRIPTION
It is sometimes desirable to not expose DB-access methods publicly. This change enables Insight to recognise and implement protected abstract methods.