### PR TITLE
ChildClass.ParentId should map to ParentClass.Id. (Issue #238)

### DIFF
--- a/Insight.Tests/GroupByTests.cs
+++ b/Insight.Tests/GroupByTests.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using ChildMappingTests =Insight.Tests.StructureTest_ChildMappingHelperUnitTests;
 
 namespace Insight.Tests
 {
@@ -357,6 +358,35 @@ namespace Insight.Tests
 				Assert.AreEqual(1, parent.Children[0].ParentKey);
 				Assert.AreEqual(30, parent.Children[0].ChildKey);
 			}
+
+			/// <summary>
+			/// Detecting Child's parent id by looking at Parent's ID
+			/// Handle InvoiceLine.Invoice_ID => Invoice.ID
+			/// aka Glass.BeerId ->Beer.Id
+			/// New Functionality (see issue 238 in root repo) 
+			/// </summary>
+			[Test]
+			public void List_MappingOfParentID_ByParentPK_NakedId()
+			{
+				var beer = Connection().QuerySql(
+								"SELECT ID=1, Int2=10; " +
+								"SELECT ID=30, Beer238_ID=1, Value=40" + " UNION " +
+								"SELECT ID=31, Beer238_ID=1, Value=41"
+								, null,
+								Query.Returns(Some<ChildMappingTests.TestClasses.Beer238>.Records)
+								.ThenChildren(Some<ChildMappingTests.TestClasses.Glass238b>.Records))
+								.First();
+
+				Assert.AreEqual(1, beer.ID = 1);
+				Assert.AreEqual(2, beer.GlassesB.Count);
+				Assert.IsNull(beer.GlassesA);
+				Assert.AreEqual(2, beer.GlassesB.Count);
+				Assert.AreEqual(1, beer.GlassesB[0].Beer238_ID);
+				Assert.AreEqual(1, beer.GlassesB[1].Beer238_ID);
+				Assert.AreEqual(40, beer.GlassesB[0].Value);
+				Assert.AreEqual(41, beer.GlassesB[1].Value);
+			}
+
 		}
 		#endregion
 

--- a/Insight.Tests/StructureTests.cs
+++ b/Insight.Tests/StructureTests.cs
@@ -343,6 +343,31 @@ namespace Insight.Tests
 			Assert.AreEqual("Invoice_id", result.ElementAt(0));
 		}
 
+		/// <summary>
+		/// Issue 238: Support myClass.BeerId ->Beer.ID
+		/// </summary>
+		[Test]
+		public void GetParentIDAccessor_WhenPKIsJustId()
+		{
+			var result = ChildMapperTestingHelper.FindParentIDAccessor(typeof(TestClasses.Glass238a), null, typeof(TestClasses.Beer238));
+
+			Assert.AreEqual(1, result.Count());
+			Assert.AreEqual("Beer238ID", result.ElementAt(0));
+		}
+
+		/// <summary>
+        /// Issue 238: Support myClass.BeerId ->Beer.ID
+        /// </summary>
+		[Test]
+		public void GetParentIDAccessor_WhenPKIsJustId_Underscored()
+		{
+			var result = ChildMapperTestingHelper.FindParentIDAccessor(typeof(TestClasses.Glass238b), null, typeof(TestClasses.Beer238));
+
+			Assert.AreEqual(1, result.Count());
+			Assert.AreEqual("Beer238_ID", result.ElementAt(0));
+		}
+
+
 		// throws System.InvalidOperationException 'Sequence contains more than one matching element'
 		// This was barfing on   public int Paid as it end with ID			 
 		/// It should first try to match to [ClassName]ID aka  public int ClassWithSuffixedId;  
@@ -642,6 +667,26 @@ namespace Insight.Tests
 				public int ParentId;
 				public ChildWithGenericNames ChildWithGenericNames;
 				public string Name;
+			}
+
+			public class Beer238
+			{
+				public int ID;
+				public IList<Glass238a> GlassesA;
+				public IList<Glass238b> GlassesB;
+			}
+
+			public class Glass238a
+			{
+				public int ID;
+				public int Beer238ID;
+			}
+
+			public class Glass238b
+			{
+				public int ID;
+				public int Beer238_ID;
+				public int Value;
 			}
 
 		}


### PR DESCRIPTION
Code and tests to address issue #238.  Replaces pull request #240 which has extra commits due to a problem with my fork from way back.

ChildClass.ParentId should map to ParentClass.Id.  

E.g. InvoiceLine.Invoice_ID -> Invoice.ID

Or mapping MyClass.BeerId -> Beer.ID