### PR TITLE
Backwards compatible VS2015 debugger fix

### DIFF
--- a/Insight.Database/CodeGenerator/InterfaceGenerator.cs
+++ b/Insight.Database/CodeGenerator/InterfaceGenerator.cs
@@ -61,7 +61,9 @@ namespace Insight.Database.CodeGenerator
 		{
 			// make a new assembly for the generated types
 			AssemblyName an = Assembly.GetExecutingAssembly().GetName();
-			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
+            // following line is just a workaround for VS2015 debugger https://github.com/jonwagner/Insight.Database/issues/224
+            an.Name += ".Tmp";
+            AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
 
 			_moduleBuilder = ab.DefineDynamicModule(an.Name);
 		}

--- a/Insight.Database/CodeGenerator/InterfaceGenerator.cs
+++ b/Insight.Database/CodeGenerator/InterfaceGenerator.cs
@@ -61,10 +61,13 @@ namespace Insight.Database.CodeGenerator
 		{
 			// make a new assembly for the generated types
 			AssemblyName an = Assembly.GetExecutingAssembly().GetName();
-            // following line is just a workaround for VS2015 debugger https://github.com/jonwagner/Insight.Database/issues/224
-            an.Name += ".Tmp";
-            AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
 
+			// TODO remove debugger condition for v6
+			if (StaticFieldStorage.DebuggerIsAttached())  // Make the dynamic assembly have a unique name.  Fixes debugger issue #224.  
+				an.Name = an.Name + ".DynamicAssembly";
+
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
+			
 			_moduleBuilder = ab.DefineDynamicModule(an.Name);
 		}
 		#endregion
@@ -151,7 +154,11 @@ namespace Insight.Database.CodeGenerator
 #else
 				if (e.HResult == -2146233054)
 #endif
-					throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, "{0} is inaccessible to Insight.Database. Make sure that the interface is public, or add [assembly: System.Runtime.CompilerServices.InternalsVisibleTo(\"Insight.Database\")] to your assembly. If the interface is nested, then it must be public to the world, or public to the assembly while using the InternalsVisibleTo attribute.", type.FullName));
+					throw new InvalidOperationException(String.Format(CultureInfo.InvariantCulture, 
+						"{0} is inaccessible to Insight.Database. Make sure that the interface is public, or add " +
+						"[assembly:InternalsVisibleTo(\"Insight.Database\")] and [assembly:InternalsVisibleTo(\"Insight.Database.DynamicAssembly\")] " +
+						"to your assembly (System.Runtime.CompilerServices).  If the interface is nested, then it must be public to the world, " +
+						"or public to the assembly while using the InternalsVisibleTo attribute.", type.FullName));
 
 				throw;
 			}

--- a/Insight.Database/CodeGenerator/StaticFieldStorage.cs
+++ b/Insight.Database/CodeGenerator/StaticFieldStorage.cs
@@ -8,75 +8,77 @@ using System.Threading.Tasks;
 
 namespace Insight.Database.CodeGenerator
 {
-	/// <summary>
-	/// Allows storage of a static variable in a way that can be easily emitted into IL.
-	/// </summary>
-	/// <remarks>
-	/// We store the information in the static fields of a class because it is easy to access them
-	/// in the IL of a DynamicMethod.
-	/// </remarks>
-	class StaticFieldStorage
-	{
-		/// <summary>
-		/// The shared module that stores all of the static variables.
-		/// </summary>
-		private static ModuleBuilder _dynamicModule;
+    /// <summary>
+    /// Allows storage of a static variable in a way that can be easily emitted into IL.
+    /// </summary>
+    /// <remarks>
+    /// We store the information in the static fields of a class because it is easy to access them
+    /// in the IL of a DynamicMethod.
+    /// </remarks>
+    class StaticFieldStorage
+    {
+        /// <summary>
+        /// The shared module that stores all of the static variables.
+        /// </summary>
+        private static ModuleBuilder _dynamicModule;
 
-		/// <summary>
-		/// The cache of the static fields.
-		/// </summary>
-		private static Dictionary<Tuple<ModuleBuilder, object>, FieldInfo> _fields = new Dictionary<Tuple<ModuleBuilder, object>, FieldInfo>();
+        /// <summary>
+        /// The cache of the static fields.
+        /// </summary>
+        private static Dictionary<Tuple<ModuleBuilder, object>, FieldInfo> _fields = new Dictionary<Tuple<ModuleBuilder, object>, FieldInfo>();
 
-		/// <summary>
-		/// Initializes static members of the StaticFieldStorage class.
-		/// </summary>
-		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
-		static StaticFieldStorage()
-		{
-			// create a shared assembly for all of the static fields to live in
-			AssemblyName an = Assembly.GetExecutingAssembly().GetName();
-			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
-			_dynamicModule = ab.DefineDynamicModule(an.Name);
-		}
+        /// <summary>
+        /// Initializes static members of the StaticFieldStorage class.
+        /// </summary>
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
+        static StaticFieldStorage()
+        {
+            // create a shared assembly for all of the static fields to live in
+            AssemblyName an = Assembly.GetExecutingAssembly().GetName();
+            // following line is just a workaround for VS2015 debugger https://github.com/jonwagner/Insight.Database/issues/224
+            an.Name += ".Tmp"; 
+            AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
+            _dynamicModule = ab.DefineDynamicModule(an.Name);
+        }
 
-		/// <summary>
-		/// Emits the value stored in static storage.
-		/// </summary>
-		/// <param name="il">The ILGenerator to emit to.</param>
-		/// <param name="value">The value to emit.</param>
-		/// <param name="moduleBuilder">The module to write to or null to use the default module.</param>
-		public static void EmitLoad(ILGenerator il, object value, ModuleBuilder moduleBuilder = null)
-		{
-			FieldInfo field;
+        /// <summary>
+        /// Emits the value stored in static storage.
+        /// </summary>
+        /// <param name="il">The ILGenerator to emit to.</param>
+        /// <param name="value">The value to emit.</param>
+        /// <param name="moduleBuilder">The module to write to or null to use the default module.</param>
+        public static void EmitLoad(ILGenerator il, object value, ModuleBuilder moduleBuilder = null)
+        {
+            FieldInfo field;
 
-			var key = Tuple.Create(moduleBuilder ?? _dynamicModule, value);
+            var key = Tuple.Create(moduleBuilder ?? _dynamicModule, value);
 
-			if (!_fields.TryGetValue(key, out field))
-			{
-				field = CreateField(key.Item1, value);
-				_fields[key] = field;
-			}
+            if (!_fields.TryGetValue(key, out field))
+            {
+                field = CreateField(key.Item1, value);
+                _fields[key] = field;
+            }
 
-			il.Emit(OpCodes.Ldsfld, field);
-		}
+            il.Emit(OpCodes.Ldsfld, field);
+        }
 
-		/// <summary>
-		/// Creates a static field that contains the given value.
-		/// </summary>
-		/// <param name="moduleBuilder">The modulebuilder to write to.</param>
-		/// <param name="value">The value to store.</param>
-		/// <returns>A static field containing the value.</returns>
-		private static FieldInfo CreateField(ModuleBuilder moduleBuilder, object value)
-		{
-			// create a type based on DbConnectionWrapper and call the default constructor
-			TypeBuilder tb = moduleBuilder.DefineType(Guid.NewGuid().ToString());
-			tb.DefineField("_storage", value.GetType(), FieldAttributes.Static | FieldAttributes.Public);
-			Type t = tb.CreateType();
+        /// <summary>
+        /// Creates a static field that contains the given value.
+        /// </summary>
+        /// <param name="moduleBuilder">The modulebuilder to write to.</param>
+        /// <param name="value">The value to store.</param>
+        /// <returns>A static field containing the value.</returns>
+        private static FieldInfo CreateField(ModuleBuilder moduleBuilder, object value)
+        {
+            // create a type based on DbConnectionWrapper and call the default constructor
+            TypeBuilder tb = moduleBuilder.DefineType(Guid.NewGuid().ToString());
+            tb.DefineField("_storage", value.GetType(), FieldAttributes.Static | FieldAttributes.Public);
+            Type t = tb.CreateType();
 
-			var field = t.GetField("_storage", BindingFlags.Static | BindingFlags.Public);
-			field.SetValue(null, value);
+            var field = t.GetField("_storage", BindingFlags.Static | BindingFlags.Public);
+            field.SetValue(null, value);
 
-			return field;
-		}
-	}
+            return field;
+        }
+    }
 }

--- a/Insight.Database/CodeGenerator/StaticFieldStorage.cs
+++ b/Insight.Database/CodeGenerator/StaticFieldStorage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reflection;
 using System.Reflection.Emit;
@@ -8,77 +9,103 @@ using System.Threading.Tasks;
 
 namespace Insight.Database.CodeGenerator
 {
-    /// <summary>
-    /// Allows storage of a static variable in a way that can be easily emitted into IL.
-    /// </summary>
-    /// <remarks>
-    /// We store the information in the static fields of a class because it is easy to access them
-    /// in the IL of a DynamicMethod.
-    /// </remarks>
-    class StaticFieldStorage
-    {
-        /// <summary>
-        /// The shared module that stores all of the static variables.
-        /// </summary>
-        private static ModuleBuilder _dynamicModule;
+	/// <summary>
+	/// Allows storage of a static variable in a way that can be easily emitted into IL.
+	/// </summary>
+	/// <remarks>
+	/// We store the information in the static fields of a class because it is easy to access them
+	/// in the IL of a DynamicMethod.
+	/// </remarks>
+	class StaticFieldStorage
+	{
+	   /// <summary>
+	   /// The shared module that stores all of the static variables.
+	   /// </summary>
+		private static ModuleBuilder _dynamicModule;
 
-        /// <summary>
-        /// The cache of the static fields.
-        /// </summary>
-        private static Dictionary<Tuple<ModuleBuilder, object>, FieldInfo> _fields = new Dictionary<Tuple<ModuleBuilder, object>, FieldInfo>();
+		/// <summary>
+		/// The cache of the static fields.
+		/// </summary>
+		private static Dictionary<Tuple<ModuleBuilder, object>, FieldInfo> _fields = new Dictionary<Tuple<ModuleBuilder, object>, FieldInfo>();
 
-        /// <summary>
-        /// Initializes static members of the StaticFieldStorage class.
-        /// </summary>
-        [System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
-        static StaticFieldStorage()
-        {
-            // create a shared assembly for all of the static fields to live in
-            AssemblyName an = Assembly.GetExecutingAssembly().GetName();
-            // following line is just a workaround for VS2015 debugger https://github.com/jonwagner/Insight.Database/issues/224
-            an.Name += ".Tmp"; 
-            AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
-            _dynamicModule = ab.DefineDynamicModule(an.Name);
-        }
+		/// <summary>
+		/// Initializes static members of the StaticFieldStorage class.
+		/// </summary>
+		[System.Diagnostics.CodeAnalysis.SuppressMessage("Microsoft.Performance", "CA1810:InitializeReferenceTypeStaticFieldsInline")]
+		static StaticFieldStorage()
+		{
+			// create a shared assembly for all of the static fields to live in
+			AssemblyName an = Assembly.GetExecutingAssembly().GetName();
 
-        /// <summary>
-        /// Emits the value stored in static storage.
-        /// </summary>
-        /// <param name="il">The ILGenerator to emit to.</param>
-        /// <param name="value">The value to emit.</param>
-        /// <param name="moduleBuilder">The module to write to or null to use the default module.</param>
-        public static void EmitLoad(ILGenerator il, object value, ModuleBuilder moduleBuilder = null)
-        {
-            FieldInfo field;
+			// TODO remove debugger condition for v6
+			if (DebuggerIsAttached())  // Make the dynamic assembly have a unique name.  Fixes debugger issue #224.  
+				an.Name = an.Name + ".DynamicAssembly";
 
-            var key = Tuple.Create(moduleBuilder ?? _dynamicModule, value);
+			AssemblyBuilder ab = AppDomain.CurrentDomain.DefineDynamicAssembly(an, AssemblyBuilderAccess.Run);
+			_dynamicModule = ab.DefineDynamicModule(an.Name);
+		}
 
-            if (!_fields.TryGetValue(key, out field))
-            {
-                field = CreateField(key.Item1, value);
-                _fields[key] = field;
-            }
+		/// <summary>
+		/// Emits the value stored in static storage.
+		/// </summary>
+		/// <param name="il">The ILGenerator to emit to.</param>
+		/// <param name="value">The value to emit.</param>
+		/// <param name="moduleBuilder">The module to write to or null to use the default module.</param>
+		public static void EmitLoad(ILGenerator il, object value, ModuleBuilder moduleBuilder = null)
+		{
+			FieldInfo field;
 
-            il.Emit(OpCodes.Ldsfld, field);
-        }
+			var key = Tuple.Create(moduleBuilder ?? _dynamicModule, value);
 
-        /// <summary>
-        /// Creates a static field that contains the given value.
-        /// </summary>
-        /// <param name="moduleBuilder">The modulebuilder to write to.</param>
-        /// <param name="value">The value to store.</param>
-        /// <returns>A static field containing the value.</returns>
-        private static FieldInfo CreateField(ModuleBuilder moduleBuilder, object value)
-        {
-            // create a type based on DbConnectionWrapper and call the default constructor
-            TypeBuilder tb = moduleBuilder.DefineType(Guid.NewGuid().ToString());
-            tb.DefineField("_storage", value.GetType(), FieldAttributes.Static | FieldAttributes.Public);
-            Type t = tb.CreateType();
+			if (!_fields.TryGetValue(key, out field))
+			{
+				field = CreateField(key.Item1, value);
+				_fields[key] = field;
+			}
 
-            var field = t.GetField("_storage", BindingFlags.Static | BindingFlags.Public);
-            field.SetValue(null, value);
+			il.Emit(OpCodes.Ldsfld, field);
+		}
 
-            return field;
-        }
-    }
+		/// <summary>
+		/// Creates a static field that contains the given value.
+		/// </summary>
+		/// <param name="moduleBuilder">The modulebuilder to write to.</param>
+		/// <param name="value">The value to store.</param>
+		/// <returns>A static field containing the value.</returns>
+		private static FieldInfo CreateField(ModuleBuilder moduleBuilder, object value)
+		{
+			// create a type based on DbConnectionWrapper and call the default constructor
+			TypeBuilder tb = moduleBuilder.DefineType(Guid.NewGuid().ToString());
+			tb.DefineField("_storage", value.GetType(), FieldAttributes.Static | FieldAttributes.Public);
+			Type t = tb.CreateType();
+
+			var field = t.GetField("_storage", BindingFlags.Static | BindingFlags.Public);
+			field.SetValue(null, value);
+
+			return field;
+		}
+
+		private static bool? _isDebuggerAttached;
+
+		/// <summary>
+		/// Indicates if the debugger is attached.  Only evaluated once so that the answer is stable
+		/// Temporary method, remove in v6
+		/// </summary>
+		internal static bool DebuggerIsAttached()
+		{
+			if (!_isDebuggerAttached.HasValue)
+				try
+				{
+					_isDebuggerAttached = Debugger.IsAttached;
+				}
+				catch
+					(Exception)
+				{
+					_isDebuggerAttached = false;
+				}
+
+			return _isDebuggerAttached.Value;
+		}
+
+	}
 }

--- a/Insight.Tests/InterfaceTests.cs
+++ b/Insight.Tests/InterfaceTests.cs
@@ -7,12 +7,17 @@ using NUnit.Framework;
 using Insight.Database;
 using System.Data.Common;
 using System.Data;
+using System.Runtime.CompilerServices;
 using System.Threading;
 using Insight.Tests.Cases;
 using Insight.Database.Reliable;
 
 // since the interface and types are private, we have to let insight have access to them
-[assembly: System.Runtime.CompilerServices.InternalsVisibleTo("Insight.Database")]
+[assembly: InternalsVisibleTo("Insight.Database")]
+
+// TODO: uncomment this InternalsVisibleTo in v6:
+// To _debug_ some unit test you will need to enable this[assembly: InternalsVisibleTo("Insight.Database.DynamicAssembly")]
+// it should remain commented out in v5 to ensure we preserve Insight's ability to access non-public strcutures
 
 namespace Insight.Tests
 {

--- a/Insight.Tests/SyncQueryCoreTests.cs
+++ b/Insight.Tests/SyncQueryCoreTests.cs
@@ -52,6 +52,21 @@ namespace Insight.Tests
 		}
 		#endregion
 
+
+		[Test]
+		public void TestFastExpandoResult()
+		{
+			var result = Connection().QuerySql("SELECT Field123=123, FieldAbc='abC'");
+
+			Assert.AreEqual(1, result.Count());
+
+			dynamic row = result.First();
+			Assert.IsNotNull(row);
+
+			Assert.AreEqual(row.Field123, 123);
+			Assert.AreEqual(row.FieldAbc, "abC");
+		}
+
 		[Test]
 		public void TestChildrenWithAutoMapping()
 		{


### PR DESCRIPTION
Backwards compatible VS2015 debugger fix for v5.x.  (Renames dynamic assembly to not conflict w/ Insight.Database only when a debugger is attached).

Address #224 and replaces pull request #267.
