### PR TITLE
Test for Setting Id via 'Select Scope Identity'

### DIFF
--- a/Insight.Tests/Cases/Records.cs
+++ b/Insight.Tests/Cases/Records.cs
@@ -17,6 +17,7 @@ namespace Insight.Tests.Cases
 		public const string SelectAllProc = "SelectAllBeer";
 		public const string SelectAllChildrenProc = "SelectAllBeerChildren";
 		public const string InsertProc = "InsertBeer";
+		public const string InsertProcScopeIdentity = "InsertBeer_ScopeIdentity";
 		public const string InsertManyProc = "InsertBeers";
 
 		public static Beer GetSample()

--- a/Insight.Tests/InsightDbTest.sql
+++ b/Insight.Tests/InsightDbTest.sql
@@ -115,6 +115,21 @@ CREATE PROC InsertByTable(@OtherValue int, @Items [InsertByTableType] READONLY) 
 		SELECT Text, @OtherValue FROM @Items
 GO
 
+CREATE PROCEDURE [dbo].[InsertBeer_ScopeIdentity]
+(
+	@Name varchar(256) = NULL,
+	@Style varchar(256) = NULL
+)
+AS
+
+	INSERT INTO [dbo].[Beer] ([Name], [Style])
+		VALUES 	(@Name,	@Style)
+
+	SELECT SCOPE_IDENTITY() AS [Id]
+
+GO
+
+
 ----------------------------------------------------------
 -- General test types
 ----------------------------------------------------------

--- a/Insight.Tests/SyncInsertTests.cs
+++ b/Insight.Tests/SyncInsertTests.cs
@@ -77,6 +77,29 @@ namespace Insight.Tests
 		}
 
 		[Test]
+		public void TestInsertWithIDReturn_ScopeIdentity()
+		{
+			using (var c = Connection().OpenWithTransaction())
+			{
+				var beer = Beer.GetSample();
+				c.Insert(Beer.InsertProcScopeIdentity, beer);
+				beer.VerifySample();
+			}
+		}
+
+
+		[Test]
+		public void TestInsertWithIDReturn_ScopeIdentity_SQL()
+		{
+			using (DbConnectionWrapper c = Connection().OpenWithTransaction())
+			{
+				var beer = Beer.GetSample();
+				c.InsertSql("INSERT INTO[dbo].[Beer] ([Name], [Style]) VALUES(@Name , @Style ); SELECT SCOPE_IDENTITY() AS [Id]", beer);
+				beer.VerifySample();
+			}
+		}
+
+		[Test]
 		public void TestInsertListWithIDReturn()
 		{
 			using (var c = Connection().OpenWithTransaction())


### PR DESCRIPTION
Tests for ensuring object id is properly set when Identity is set via older 'SELECT SCOPE_IDENTITY() AS [Id]' method.

Using this to close #246 as the tests indicate there is no issue.