### PR TITLE
fixing rare concurrency error (2)

### DIFF
--- a/Insight.Database/Serialization/DbSerializationRule.cs
+++ b/Insight.Database/Serialization/DbSerializationRule.cs
@@ -25,7 +25,7 @@ namespace Insight.Database
 		/// <summary>
 		/// The cached serializers.
 		/// </summary>
-        private static ConcurrentDictionary<Type, IDbObjectSerializer> _cachedSerializers = new ConcurrentDictionary<Type, IDbObjectSerializer>();
+		private static ConcurrentDictionary<Type, IDbObjectSerializer> _cachedSerializers = new ConcurrentDictionary<Type, IDbObjectSerializer>();
 
 		/// <summary>
 		/// The default serialization handler.
@@ -172,7 +172,7 @@ namespace Insight.Database
 					if (!_cachedSerializers.TryGetValue(prop.Serializer, out serializer))
 					{
 						serializer = (IDbObjectSerializer)System.Activator.CreateInstance(prop.Serializer);
-						_cachedSerializers.TryAdd(prop.Serializer, serializer);
+						_cachedSerializers.GetOrAdd(prop.Serializer, serializer);
 					}
 
 					return serializer;

--- a/Insight.Database/Serialization/DbSerializationRule.cs
+++ b/Insight.Database/Serialization/DbSerializationRule.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Data;
 using System.Globalization;
@@ -24,7 +25,7 @@ namespace Insight.Database
 		/// <summary>
 		/// The cached serializers.
 		/// </summary>
-		private static Dictionary<Type, IDbObjectSerializer> _cachedSerializers = new Dictionary<Type, IDbObjectSerializer>();
+        private static ConcurrentDictionary<Type, IDbObjectSerializer> _cachedSerializers = new ConcurrentDictionary<Type, IDbObjectSerializer>();
 
 		/// <summary>
 		/// The default serialization handler.
@@ -171,7 +172,7 @@ namespace Insight.Database
 					if (!_cachedSerializers.TryGetValue(prop.Serializer, out serializer))
 					{
 						serializer = (IDbObjectSerializer)System.Activator.CreateInstance(prop.Serializer);
-						_cachedSerializers.Add(prop.Serializer, serializer);
+						_cachedSerializers.TryAdd(prop.Serializer, serializer);
 					}
 
 					return serializer;


### PR DESCRIPTION
This is JakeTaylorPro's request, #234.  

I made the Jon's requested revision in #224 (Jake is travelling for us rolling out a big new system).

 Umm, my intent was to place the small change right on Jake's branch very cleanly, but I'm not that smart.  I retained JAke's commit in the madness, but I had to open a new pull request :(

Jon you said 

> Since this is a concurrentdictionary now, can we change the code from TryGetValue/TryAdd to GetOrAdd? 

I changed it to TryGetValue+GetOrAdd.  I don't see how you reduce it to just a GetOrAdd as that would seem to circumvent the caching.

Side note: the last the commit looks noisy, but it seems to be the result of a pre-existing issue with line endings.
