### PR TITLE
Modified SqlInsightDbProvider.CloneDbConnection to use the ConnectionString property of the source connection

### DIFF
--- a/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
+++ b/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
@@ -92,7 +92,7 @@ namespace Insight.Database
             if (!builder.IntegratedSecurity && builder.Password.IsNullOrWhiteSpace())
                 throw new InvalidOperationException("The database connection has already been opened and the password has been cleared. In order to use password-based credentials with parallel connections, set Persist Security Info=True on your connection string.");
 
-            return new SqlConnection(builder.ConnectionString);
+            return new SqlConnection(connection.ConnectionString);
         }
 
 		/// <summary>


### PR DESCRIPTION
In one of my apps that use auto-generated interfaces with AsParallel(), and do a lot of concurrent operations, I noticed that there was a large number of strings created and collected. It turned out that it was due to Insight using `builder.ConnectionString` instead of `connection.ConnectionString` when cloning connections.

The connection string is the same as the one that would be created by the builder, and has the added benefit that it doesn't introduce any new allocation, thus reducing GC pressure during intense usage.