### PR TITLE
Allow TableValuedParameters to be used inside a transaction

### DIFF
--- a/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
+++ b/Insight.Database.Providers.Default/SqlInsightDbProvider.cs
@@ -442,7 +442,7 @@ namespace Insight.Database
 				p.SqlDbType = SqlDbType.Structured;
 
 				var tableTypes = new String[] { p.ParameterName, listType.Name, listType.Name + "Table" };
-				p.TypeName = tableTypes.Where(t => command.Connection.ExecuteScalarSql<int>("SELECT COUNT(*) FROM sys.table_types WHERE NAME = @name", new { name = t }) > 0).First();
+				p.TypeName = tableTypes.Where(t => command.Connection.ExecuteScalarSql<int>("SELECT COUNT(*) FROM sys.table_types WHERE NAME = @name", new { name = t }, transaction: command.Transaction) > 0).First();
 			}
 
 			return p.TypeName;

--- a/Insight.Tests/TableValuedParametersTests.cs
+++ b/Insight.Tests/TableValuedParametersTests.cs
@@ -42,6 +42,19 @@ namespace Insight.Tests
 
 			Assert.That(roundtrippedValue, Is.EqualTo("classes are better"));
 		}
+
+		[Test]
+		public void Given_a_table_type_with_a_property_that_is_a_class_which_requires_serialisation_When_using_the_type_in_an_sql_statement_in_a_transaction_Then_it_does_not_explode()
+		{
+			DbSerializationRule.Serialize<MyCustomClass>(new MyCustomSerialiser<MyCustomClass>());
+
+			using (var connection = ConnectionWithTransaction())
+			{
+				var roundtrippedValue = connection.ExecuteScalarSql<string>("select top 1 String from @values", new {values = new[] {new InsightTestDataString() {String = new MyCustomClass {Value = "classes are better"}}}});
+
+				Assert.That(roundtrippedValue, Is.EqualTo("classes are better"));
+			}
+		}
 	}
 
 	public class TableValuedParameterWithStructsTests : BaseTest


### PR DESCRIPTION
## Description
https://github.com/jonwagner/Insight.Database/issues/360

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->
```
[x] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[x] No
```
### Any other comment
<!-- Provide additional relevant info here. -->
I have confirmed the fix by undoing the update and the unit test gets the same exception