### PR TITLE
Fixes issue #364: results mapping for nullable enums.

### DIFF
--- a/Insight.Tests/DbReaderTests.cs
+++ b/Insight.Tests/DbReaderTests.cs
@@ -19,9 +19,66 @@ namespace Insight.Tests
 			public int Int;
 			public string String;
 			public TimeSpan TimeSpan;
+			public TestEnum TestEnum;
+			public TestEnum? NullableTestEnum;
+		}
+		
+		enum TestEnum
+		{
+			One = 1,
+			Two = 2,
+			Three = 3
 		}
 		#endregion
 
+		[Test]
+		public void TestThatEnumPropertyIsDeserialized()
+		{
+			var list = Connection().QuerySql<Data>("SELECT TestEnum='Two'", new { });
+
+			Assert.IsNotNull(list);
+			Assert.AreEqual(1, list.Count);
+			var item = list[0];
+			Assert.IsNotNull(item);
+			Assert.AreEqual(TestEnum.Two, item.TestEnum);
+		}
+		
+		[Test]
+		public void TestThatEnumPropertyIsDeserializedFromInt()
+		{
+			var list = Connection().QuerySql<Data>("SELECT TestEnum=2", new { });
+
+			Assert.IsNotNull(list);
+			Assert.AreEqual(1, list.Count);
+			var item = list[0];
+			Assert.IsNotNull(item);
+			Assert.AreEqual(TestEnum.Two, item.TestEnum);
+		}
+		
+		[Test]
+		public void TestThatNullableEnumPropertyIsDeserialized()
+		{
+			var list = Connection().QuerySql<Data>("SELECT NullableTestEnum='Two'", new { });
+
+			Assert.IsNotNull(list);
+			Assert.AreEqual(1, list.Count);
+			var item = list[0];
+			Assert.IsNotNull(item);
+			Assert.AreEqual(TestEnum.Two, item.NullableTestEnum);
+		}
+		
+		[Test]
+		public void TestThatNullableEnumPropertyIsDeserializedFromInt()
+		{
+			var list = Connection().QuerySql<Data>("SELECT NullableTestEnum=2", new { });
+
+			Assert.IsNotNull(list);
+			Assert.AreEqual(1, list.Count);
+			var item = list[0];
+			Assert.IsNotNull(item);
+			Assert.AreEqual(TestEnum.Two, item.NullableTestEnum);
+		}
+		
 		[Test]
 		public void TestThatSingleClassIsDeserialized()
 		{


### PR DESCRIPTION
Results mapping for nullable enums is not working.

## Description
This PR fixes the issue #364.
The results mapping for nullable enum properties did not work.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->
```
[x] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[x] No
```
### Any other comment
<!-- Provide additional relevant info here. -->
Hello, please review and merge (if you think the PR looks ok) this fix for nullable enums mapping. Thank you.