### PR TITLE
fixed bug where only default XmlObjectSerializer is being returned ev…

### DIFF
--- a/Insight.Database.Core/Serialization/DbSerializationRule.cs
+++ b/Insight.Database.Core/Serialization/DbSerializationRule.cs
@@ -184,7 +184,7 @@ namespace Insight.Database
 		internal static IDbObjectSerializer GetSerializer(IDbCommand command, IDataParameter parameter, ClassPropInfo prop)
 		{
 			if (InsightDbProvider.For(parameter).IsXmlParameter(command, parameter))
-				return XmlObjectSerializer.Serializer;
+				return GetCustomSerializer(prop) ?? XmlObjectSerializer.Serializer;
 
 			return EvaluateRules(prop);
 		}
@@ -199,7 +199,7 @@ namespace Insight.Database
 		internal static IDbObjectSerializer GetSerializer(IDataReader reader, int column, ClassPropInfo prop)
 		{
 			if (InsightDbProvider.For(reader).IsXmlColumn(reader, column))
-				return XmlObjectSerializer.Serializer;
+				return GetCustomSerializer(prop) ?? XmlObjectSerializer.Serializer;
 
 			return EvaluateRules(prop);
 		}
@@ -211,7 +211,17 @@ namespace Insight.Database
 		/// <returns>The serializer.</returns>
 		internal static IDbObjectSerializer EvaluateRules(ClassPropInfo prop)
 		{
-			return _handlers.Select(h => h.GetSerializer(prop.Type, prop.MemberType, prop.Name)).Where(s => s != null).FirstOrDefault() ?? _defaultConfig.GetSerializer(prop.Type, prop.MemberType, prop.Name);
+			return GetCustomSerializer(prop) ?? _defaultConfig.GetSerializer(prop.Type, prop.MemberType, prop.Name);
+		}
+
+		/// <summary>
+		/// Gets the custom serializer.
+		/// </summary>
+		/// <param name="prop">The property that is being bound.</param>
+		/// <returns>The serializer.</returns>
+		internal static IDbObjectSerializer GetCustomSerializer(ClassPropInfo prop)
+		{
+			return _handlers.Select(h => h.GetSerializer(prop.Type, prop.MemberType, prop.Name)).Where(s => s != null).FirstOrDefault();
 		}
 		#endregion
 	}


### PR DESCRIPTION
…en though we're setting rules for custom one

## Description
DbSerializerRules aren't being respected for Xml column types, if you add a custom serializer, it will just be ignored and the default XmlObjectSerializer keeps being returned instead

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->
```
[x] Bug.
[ ] Feature.
[ ] Code style update (formatting, local variables).
[ ] Refactoring (no functional changes, no api changes).
[ ] Documentation content changes.
[ ] Other (please describe below).
```

## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->
```
[ ] Yes
[x] No
```
### Any other comment
My first real PR on github, hopefully it checks out okay! How often are nuget packages published? Really could use this one as a package.