### PR TITLE
Add support for parameter type mapping when the type is an IEnumerable

### DIFF
--- a/Insight.Database.Core/CodeGenerator/DbParameterGenerator.cs
+++ b/Insight.Database.Core/CodeGenerator/DbParameterGenerator.cs
@@ -262,7 +262,9 @@ namespace Insight.Database.CodeGenerator
 				provider.FixupParameter(command, dbParameter, sqlType, memberType, mapping.Member.SerializationMode);
 
 				// give a chance to override the best guess parameter
-				DbType overriddenSqlType = ColumnMapping.MapParameterDataType(memberType, command, dbParameter, sqlType);
+				DbType overriddenSqlType = sqlType;
+				if (sqlType != DbTypeEnumerable)
+					overriddenSqlType = ColumnMapping.MapParameterDataType(memberType, command, dbParameter, sqlType);
 
 				///////////////////////////////////////////////////////////////
 				// We have a parameter, start handling all of the other types
@@ -746,6 +748,12 @@ namespace Insight.Database.CodeGenerator
 							length = -1;
 						listParam.Size = length;
 					}
+
+					listParam.DbType = ColumnMapping.MapParameterDataType(isString ?
+						typeof(string) : (item?.GetType() ?? typeof(object)),
+						command,
+						parameter,
+						listParam.DbType);
 
 					command.Parameters.Add(listParam);
 				}

--- a/Insight.Database.Core/Mapping/ColumnMapping.cs
+++ b/Insight.Database.Core/Mapping/ColumnMapping.cs
@@ -122,7 +122,10 @@ namespace Insight.Database
 			if (!ParameterDataTypes.Mappers.Any())
 				return dbType;
 
-			return ParameterDataTypes.Mappers.Select(m => m.MapParameterType(type, command, parameter, dbType)).FirstOrDefault();
+			return ParameterDataTypes
+				.Mappers
+				.Aggregate(dbType,
+					(previousDbType, parameterTypeMapper) => parameterTypeMapper.MapParameterType(type, command, parameter, previousDbType));
 		}
 
 		/// <summary>


### PR DESCRIPTION
## Descrdiption
Add support for parameter type mapping when the type is an IEnumerable.  This is associated to a previous pull request I made a few months ago:  #351.  I've just discovered that this does not support IEnumerable types for example:

```
conn.QueryAsync<MyType>("SELECT * FROM dbo.MyType WHERE Id IN (@ids)", new { Ids = new[] { "a", "b", "c" });
```

A similar query today has been causing bad query plans due to mismatching data types.  The `Id` column in `MyTable` is of type `varchar` but by default the parameters are created as `nvarchar`.  This will address this issue and allow the custom type mapper to map nvarchar to varchar when it's an IEnumerable type.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [X ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).   _Unsure of how to make edits to the wiki or if you'd want to make edits prior to this branch being approved_

## Type
This pull request includes what type of changes?
- [X] Bug.

## Breaking Changes
Does this pull request introduce any breaking changes?
- [ ] Yes
- [X] No
