### PR TITLE
Correct Spelling in SqlConstructorAttribute Documentation Comment

### DIFF
--- a/Insight.Database.Core/SqlConstructorAttribute.cs
+++ b/Insight.Database.Core/SqlConstructorAttribute.cs
@@ -7,7 +7,7 @@ using System.Threading.Tasks;
 namespace Insight.Database
 {
     /// <summary>
-    /// Marks a constructor as the preffered constructor to use when deserializing objects from the database.
+    /// Marks a constructor as the preferred constructor to use when deserializing objects from the database.
     /// </summary>
     [AttributeUsage(AttributeTargets.Constructor)]
     public sealed class SqlConstructorAttribute : Attribute


### PR DESCRIPTION
## Description
Corrected misspelling in documentation.

## Checklist
- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
- [ ] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [x] Documentation content changes.
- [ ] Other (please describe below).

## Breaking Changes
Does this pull request introduce any breaking changes?

- [ ] Yes
- [x] No

### Any other comment
(n/a)
