### PR TITLE
Overrode BulkCopyAsync in DbConnectionWrapperInsightDbProvider

### DIFF
--- a/Insight.Database.Core/Providers/DbConnectionWrapperInsightDbProvider.cs
+++ b/Insight.Database.Core/Providers/DbConnectionWrapperInsightDbProvider.cs
@@ -1,11 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Linq;
-using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
-using Insight.Database.Reliable;
 
 namespace Insight.Database.Providers
 {
@@ -93,6 +91,14 @@ namespace Insight.Database.Providers
 			DbConnectionWrapper wrapped = (DbConnectionWrapper)connection;
 
 			base.BulkCopy(connection, tableName, reader, configure, options, transaction ?? wrapped.InnerTransaction);
+		}
+
+		/// <inheritdoc/>
+		public override Task BulkCopyAsync(IDbConnection connection, string tableName, IDataReader reader, Action<InsightBulkCopy> configure, InsightBulkCopyOptions options, IDbTransaction transaction, CancellationToken cancellationToken)
+		{
+			DbConnectionWrapper wrapped = (DbConnectionWrapper)connection;
+
+			return base.BulkCopyAsync(connection, tableName, reader, configure, options, transaction ?? wrapped.InnerTransaction, cancellationToken);
 		}
 	}
 }


### PR DESCRIPTION
## Description
Closes #397 
Functionality was missing for taking the DbConnectionWrapper's transaction when an IDbTransaction was not provided to the BulkCopyAsync extension method. This caused a exception to be thrown (Unexpected existing transaction: https://stackoverflow.com/questions/19117106/sqlbulkcopy-unexpected-existing-transaction).

The logic was there for the non-async BulkCopy, so I just created a similar override for BulkCopyAsync,

## Checklist
Please make sure your pull request fulfills the following requirements:

- [ ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No

### Any other comment
I didn't modify any tests as I couldn't even get them to run, but the test case to reproduce the issue here would simply involve using a DbConnectionWrapper and invoking BeginAutoTransaction on it before the BulkCopyAsync.
