### PR TITLE
Fixup dynamic datetime

### DIFF
--- a/Insight.Database.Core/CodeGenerator/DbParameterGenerator.cs
+++ b/Insight.Database.Core/CodeGenerator/DbParameterGenerator.cs
@@ -526,6 +526,7 @@ namespace Insight.Database.CodeGenerator
 					if (value != null && _typeToDbTypeMap.ContainsKey(value.GetType()))
 						dbDataParameter.DbType = _typeToDbTypeMap[value.GetType()];
 
+					provider.FixupParameter(cmd, p, p.DbType, dyn.GetType(), SerializationMode.Default);
 					cmd.Parameters.Add(p);
 				}
 			};

--- a/Insight.Tests/TypeTests.cs
+++ b/Insight.Tests/TypeTests.cs
@@ -935,6 +935,30 @@ namespace Insight.Tests
 		}
 
 		[Test]
+		public void DateFieldsShouldConvertProperlyFromDynamic()
+		{
+			var expected = DateTime.MinValue;
+			var fe = new FastExpando();
+			var feDict = fe as IDictionary<string, object>;
+
+			// send datetime and datetime? to sql
+			feDict["date"] = expected;
+			Connection().QuerySql<DateTime>("SELECT @date", fe);
+
+			feDict["date"] = (DateTime?)expected;
+			Connection().QuerySql<DateTime>("SELECT @date", fe);
+
+			feDict["date"] = expected;
+			Connection().Query<DateTime>("TestDateTime2", fe);
+
+			feDict["date"] = (DateTime?)expected;
+			var list = Connection().Query<DateTime>("TestDateTime2", new { date = (DateTime?)expected });
+
+			var result = list.First();
+			Assert.AreEqual(expected, result);
+		}
+
+		[Test]
 		public void DateFieldsShouldConvertFromString()
 		{
 			DateTime d = DateTime.Today;


### PR DESCRIPTION
…meters.

## Description
Dynamic (and FastExpando) parameter objects were failing to pass datetime2 values to commands due to missing provider.FixupParameter call, e.g. "1/1/0001 12:00:00am" was causing SqlTypeExceptions.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [X ] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [ X] No

### Any other comment
<!-- Provide additional relevant info here. -->
(n/a)
