### PR TITLE
Update MySqlConnector to 1.0.

### DIFF
--- a/Insight.Database.Providers.MySqlConnector/Insight.Database.Providers.MySqlConnector.csproj
+++ b/Insight.Database.Providers.MySqlConnector/Insight.Database.Providers.MySqlConnector.csproj
@@ -21,7 +21,7 @@
   <Import Project="..\SharedConfiguration.csproj" />
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.40.3" />
+    <PackageReference Include="MySqlConnector" Version="1.0.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Insight.Database.Core\Insight.Database.Core.csproj" />

--- a/Insight.Database.Providers.MySqlConnector/MySqlConnectorInsightDbProvider.cs
+++ b/Insight.Database.Providers.MySqlConnector/MySqlConnectorInsightDbProvider.cs
@@ -5,7 +5,7 @@ using System.Data.Common;
 using System.Globalization;
 using System.Linq;
 using System.Text.RegularExpressions;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 
 namespace Insight.Database.Providers.MySqlConnector
 {

--- a/Insight.Tests.MySqlConnector/MySqlConnectorTests.cs
+++ b/Insight.Tests.MySqlConnector/MySqlConnectorTests.cs
@@ -2,7 +2,7 @@
 using System.Linq;
 using Insight.Database;
 using NUnit.Framework;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System.Data;
 
 namespace Insight.Tests.MySqlConnector


### PR DESCRIPTION
## Description

MySqlConnector 1.0 changes the primary namespace to `MySqlConnector`: mysql-net/MySqlConnector#824; this updates all relevant code.

This starts the discussion around updating MySqlConnector to 1.0, but doesn't need to be merged until it's out of beta.

## Type
This pull request includes what type of changes?

- [ ] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [x] Other (please describe below).

Update dependency.

## Breaking Changes
Does this pull request introduce any breaking changes?

- [x] Yes
- [x] No

A consumer that was depending on MySqlConnector via this library could be broken by the change of namespace. However, that should be rare.