### PR TITLE
TVP date type issue for SQL Server

### DIFF
--- a/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
+++ b/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
@@ -35,7 +35,7 @@ namespace Insight.Database.Providers.Default
 			{ typeof(string), SqlDbType.NVarChar },
 			{ typeof(char), SqlDbType.NChar },
 			{ typeof(Guid), SqlDbType.UniqueIdentifier },
-			{ typeof(DateTime), SqlDbType.DateTime2 },
+			{ typeof(DateTime), SqlDbType.DateTime },
 			{ typeof(DateTimeOffset), SqlDbType.DateTimeOffset },
 			{ typeof(TimeSpan), SqlDbType.Time },
 			{ typeof(byte[]), SqlDbType.VarBinary },
@@ -108,6 +108,8 @@ namespace Insight.Database.Providers.Default
 			{
 				switch (dataTypeName.ToLowerInvariant())
 				{
+					case "date":
+						return SqlDbType.Date;
 					case "datetime":
 						return SqlDbType.DateTime;
 

--- a/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
+++ b/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
@@ -35,7 +35,7 @@ namespace Insight.Database.Providers.Default
 			{ typeof(string), SqlDbType.NVarChar },
 			{ typeof(char), SqlDbType.NChar },
 			{ typeof(Guid), SqlDbType.UniqueIdentifier },
-			{ typeof(DateTime), SqlDbType.DateTime },
+			{ typeof(DateTime), SqlDbType.DateTime2 },
 			{ typeof(DateTimeOffset), SqlDbType.DateTimeOffset },
 			{ typeof(TimeSpan), SqlDbType.Time },
 			{ typeof(byte[]), SqlDbType.VarBinary },

--- a/Insight.Tests/TableValuedParametersTests.cs
+++ b/Insight.Tests/TableValuedParametersTests.cs
@@ -130,6 +130,50 @@ namespace Insight.Tests
 		}
 	}
 
+	[TestFixture]
+	public class TvpWithDefaultDateTimeDataTypeIssueTests : BaseTest
+	{
+		[SetUp]
+		public void SetUp()
+		{
+			Connection().ExecuteSql("create type SimpleDateTable as table (Value date)");
+		}
+
+		[TearDown]
+		public void TearDown()
+		{
+			Connection().ExecuteSql("drop type SimpleDateTable");
+		}
+
+		[Test]
+		public void TVPs_WithDefaultDateTime_DoesNotBlowUp()
+		{
+			var sql    = "select count(*) from @values";
+			var values = new[]
+			{
+				WithDate(new DateTime(2020, 3, 17)),
+				WithDate(new DateTime()), // default(DateTime)
+				WithDate(new DateTime(2020, 3, 19)),
+				WithDate(new DateTime(2020, 3, 20))
+			};
+
+			var result = Connection().SingleSql<int>(sql, new { values });
+
+			Assert.AreEqual(result, 4);
+		}
+
+		private SimpleDate WithDate(DateTime value)
+			=> new SimpleDate(value);
+
+		public class SimpleDate
+		{
+			public SimpleDate(DateTime value)
+				=> Value = value;
+
+			public DateTime Value { get; }
+		}
+	}
+
 	#region Issue 354 Tests
 	[TestFixture]
 	public class Issue354Tests : BaseTest


### PR DESCRIPTION
## Description
Table valued parameters that include a .Net `DateTime` type fails to populate when the default value is used because the underlying SQL was trying to use `datetime` instead of `date`.  In SQL Server, `datetime` does not support dates before January 1, 1753.  The `date` type in T-SQL supports all values of the .Net `DateTime`, like `datetime2`, except it does not store the time portion.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No

### Any other comment
<!-- Provide additional relevant info here. -->
(n/a)
