### PR TITLE
Update Oracle image for docker-compose.

### DIFF
--- a/insight-docker/docker-compose.yml
+++ b/insight-docker/docker-compose.yml
@@ -20,7 +20,7 @@ services:
     - MYSQL_ALLOW_EMPTY_PASSWORD=yes
     - MYSQL_ROOT_HOST=%
     - MYSQL_DATABASE=test
- 
+
   postgres:
     image: postgres:latest
     ports:
@@ -46,7 +46,7 @@ services:
     - db2:/database
 
   oracle:
-    image: sath89/oracle-12c
+    image: truevoly/oracle-12c
     ports:
     - "1521:1521"
     environment:


### PR DESCRIPTION
## Description
<!-- please describe the issue fixed or enhancement -->
The current listing for an Oracle image in the docker-compose file, namely `sath89/oracle-12c`, no longer exists.  I updated the file to use an existing copy of the current image (first thing that came up in a search on hub.docker.com ).  Feel free to change it.  I just wanted to make sure others who attempt to use the docker-compose file would not run into the same issue.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [ ] Tests for any changes have been added (for bug fixes / features).
- [ ] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [ ] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [x] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No

### Any other comment
<!-- Provide additional relevant info here. -->
As mentioned in the description, this only updates the named docker image in the docker-compose file.  If author or maintainers wish to use a different image available, feel free to update this PR with the preferred one.
