### PR TITLE
FIXES #459 - fields with no setter and not used in constructor should…

### DIFF
--- a/Insight.Database.Core/CodeGenerator/ClassDeserializerGenerator.cs
+++ b/Insight.Database.Core/CodeGenerator/ClassDeserializerGenerator.cs
@@ -116,6 +116,19 @@ namespace Insight.Database.CodeGenerator
 			bool isStruct = type.GetTypeInfo().IsValueType;
 			ConstructorInfo constructor = createNewObject ? SelectConstructor(type) : null;
 
+			// if there is a constructor, determine which columns will be mapped to constructor parameters
+			// constructorMappings will be indexes into the mappin array (or -1 if there is no mapping)
+			var constructorParameters = (constructor != null) ? constructor.GetParameters() : null;
+			var constructorMappings = (constructor != null) ? constructorParameters.Select(p => mappings.FindIndex(m => m != null && p.Name.IsIEqualTo(m.Member.Name))).ToArray() : Array.Empty<int>();
+
+			// remove any mappings that are not settable and not used for constructor initialization
+			// this will save on translating properties we can't set and prevent issue #459
+			for (var m = 0; m < mappings.Count; m++)
+			{
+				if (mappings[m] != null && !mappings[m].Member.CanSetMember && !constructorMappings.Contains(m))
+					mappings[m] = null;
+			}
+
 			// the method can either be:
 			// createNewObject => Func<IDataReader, T>
 			// !createNewObject => Func<IDataReader, T, T>
@@ -225,16 +238,15 @@ namespace Insight.Database.CodeGenerator
                         il.Emit(OpCodes.Ldloca_S, localResult);
                 }
 
-                // if there is a constructor, then populate the values
+                // if there is a constructor, then populate the values from the pre-converted local values we created above
                 if (constructor != null)
                 {
-                    foreach (var p in constructor.GetParameters())
+					for (var p = 0; p < constructorParameters.Length; p++)
                     {
-                        var mapping = mappings.Where(m => m != null).SingleOrDefault(m => m.Member.Name.IsIEqualTo(p.Name));
-                        if (mapping != null)
-                            il.Emit(OpCodes.Ldloc, localValues[mappings.IndexOf(mapping)]);
+						if (constructorMappings[p] >= 0)
+                            il.Emit(OpCodes.Ldloc, localValues[constructorMappings[p]]);
                         else
-                            TypeHelper.EmitDefaultValue(il, p.ParameterType);
+                            TypeHelper.EmitDefaultValue(il, constructorParameters[p].ParameterType);
                     }
                 }
 

--- a/Insight.Tests/MappingTests.cs
+++ b/Insight.Tests/MappingTests.cs
@@ -681,5 +681,44 @@ namespace Insight.Tests
             Connection().SingleSql<A388>("SELECT A=1, 2");
             Connection().SingleSql<B388>("SELECT A=1, 2");
         }
+
+#region Test459
+        public class Test459 : BaseTest
+        {
+            [Test]
+            public void TestReadingPrivateSetters()
+            {
+                var o = Connection().SingleSql<PrivateSetterInt>("SELECT X=1");
+				// should map
+                Assert.AreEqual(1, o.X);
+            }
+
+            [Test]
+            public void TestReadingPrivateNoSetter()
+            {
+                var o = Connection().SingleSql<PrivateNoSetterInt>("SELECT X=1");
+				// should not map
+                Assert.AreEqual(0, o.X);
+            }
+
+            [Test]
+            public void TestReadingPrivateNoSetterWithConversion()
+            {
+                var o = Connection().SingleSql<PrivateNoSetterInt>("SELECT X='string'");
+				// should not map and should not throw due to incompatible type
+                Assert.AreEqual(0, o.X);
+            }
+
+            private class PrivateSetterInt
+            {
+                public int X { get; private set; }
+            }
+
+            private class PrivateNoSetterInt
+            {
+                public int X { get; }
+            }
+        }
+#endregion
     }
 }


### PR DESCRIPTION
This fixes Issue #459.

It cleans up which columns are mapped and transformed when deserializing an object. I think it's a simple change, but since it's such a core method, I'd appreciate a second set of eyes before I do a build