### PR TITLE
Map from decimal to money when using TVP

### DIFF
--- a/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
+++ b/Insight.Database.Providers.Default/SqlDataRecordAdapter.cs
@@ -114,6 +114,8 @@ namespace Insight.Database.Providers.Default
 						return SqlDbType.DateTime;
 					case "datetime2":
 						return SqlDbType.DateTime2;
+					case "money":
+						return SqlDbType.Money;
 				}
 			}
 

--- a/Insight.Tests/TypeTests.cs
+++ b/Insight.Tests/TypeTests.cs
@@ -1030,6 +1030,37 @@ namespace Insight.Tests
 				c.ExecuteSql("drop type [datetime2List]");
 			}
 		}
+
+		public class MoneyModel { public decimal MyMoney { get; set; } }
+		public interface IMoneyRepository
+		{
+			List<Decimal> InsertMoneyList(IList<MoneyModel> moneyTestList);
+		}
+
+		[Test]
+		public void MoneyFieldsShouldConvertInTVP()
+		{
+			var c = Connection();
+			try
+			{
+				c.ExecuteSql(@"create type [moneyList] as table( [myMoney] [money] not null )");
+				c.ExecuteSql(@"create procedure [InsertMoneyList] @moneyList as moneyList readonly as select myMoney from @moneyList");				
+
+				var expected = 12.345m;
+
+				var model = new MoneyModel { MyMoney = expected };
+				var list = new List<MoneyModel> { model, model };
+				var repo = c.As<IMoneyRepository>();
+				var results = repo.InsertMoneyList(list);
+
+				Assert.AreEqual(expected, results[0]);
+			}
+			finally
+			{
+				c.ExecuteSql("drop procedure [InsertMoneyList]");
+				c.ExecuteSql("drop type [moneyList]");
+			}
+		}
 #endregion
 
 #region Guid Tests


### PR DESCRIPTION
When using table valued parameters, Insight needs to map from the .NET
type (e.g. decimal) to the SQL Server type (e.g. decimal or money).
The mapping from the decimal .NET type to decimal SQL Server type works
by default, but if the type in SQL Server is money, values in the
decimal places are truncated and lost. Since we know the data type in
the database via metadata, use the same approach that has been taken for
datetime2 (which also has multiple SQL Server types mapping to a single
.NET type).

Note that this problem only seems to manifest itself in the .NET
Standard build. The new test failed prior to fixing when run under .NET
5, but not under .NET 4.5.1. It could be that the .NET Framework SQL
Server libraries are more forgiving of this situation.

## Description
Fixes #475.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?

- [ ] Yes
- [x] No

### Any other comment
(n/a)
