### PR TITLE
Fix false-positive duplicate detection in mapping deep member paths to TVP columns

### DIFF
--- a/Insight.Database.Core/Mapping/ColumnMapping.cs
+++ b/Insight.Database.Core/Mapping/ColumnMapping.cs
@@ -94,16 +94,14 @@ namespace Insight.Database
                 .ToArray();
 
             // remove duplicates from the list
-            var usedFields = new HashSet<ClassPropInfo>();
+            var usedFields = new HashSet<string>(StringComparer.Ordinal);
             for (int i = 0; i < array.Length; i++)
             {
                 if (array[i] == null)
                     continue;
 
-                if (usedFields.Contains(array[i].Member))
+                if (!usedFields.Add(array[i].PathToMember))
                     array[i] = null;
-                else
-                    usedFields.Add(array[i].Member);
             }
 
             return array.ToList();


### PR DESCRIPTION
## Description

This PR deals with mapping deep member paths to table-valued parameter columns.  Suppose a custom column mapper creates the following mappings:

TVP Column | Member Path
:--:|:--:
`A_X` | `A.X`
`B_X` | `B.X`

The column-mapping code [attempts to deduplicate](https://github.com/jonwagner/Insight.Database/blob/6.3.10/Insight.Database.Core/Mapping/ColumnMapping.cs#L97-L107) mappings by keeping a `HashSet` of used members.  When the code finds a member in the `HashSet`, the code knows that a mapping used the member already.  The code then avoids another mapping to the member.

The key for duplicate detection is the `ClassPropInfo` of the final member in the member path.  This causes false-positive duplicate detection in several scenarios, including:

- TVP with multiple children of the same type

  ```csharp
  class Parent
  {
      public Child A;
      public Child B;
  }
  
  class Child
  {
      public int X;
  }
  ```

- TVP with multiple children of different types that each inherit a property from the same base class

  ```csharp
  class Parent
  {
      public ChildA A;
      public ChildB B;
  }

  class ChildA : Child { /*...*/ }
  class ChildB : Child { /*...*/ }
  
  abstract class Child
  {
      public int X;
  }
  ```

This PR supports such scenarios by changing the duplicate detection key to the member path itself.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).
      - As far as I know, no documentation needs to be changed.

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).

## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No _... unless you depend on arguably buggy behaviour_

This change causes parameter data to flow to TVP columns where it previously has not.

### Any other comment
<!-- Provide additional relevant info here. -->
(n/a)
