### PR TITLE
FIX #482 - deserializer generation fails with object with no mappable columns

### DIFF
--- a/Insight.Database.Core/CodeGenerator/ClassDeserializerGenerator.cs
+++ b/Insight.Database.Core/CodeGenerator/ClassDeserializerGenerator.cs
@@ -549,9 +549,18 @@ namespace Insight.Database.CodeGenerator
 				il.Emit(OpCodes.Dup);                                       // duplicate the array
 				il.Emit(OpCodes.Ldc_I4, i);                                 // the index to store to
 
-				// call the deserializer for the subobject
-				il.Emit(OpCodes.Ldarg_0);
-				il.Emit(OpCodes.Call, deserializers[i]);
+				// #482 - if the object doesn't have any mappable columns, it won't have a deserilizer
+				if (deserializers[i] == null)
+				{
+					// since we're going to call a callback to handle the value, just set it to null
+					il.Emit(OpCodes.Ldnull);
+				}
+				else
+				{
+					// call the deserializer for the subobject
+					il.Emit(OpCodes.Ldarg_0);
+					il.Emit(OpCodes.Call, deserializers[i]);
+				}
 
 				// for the root object, store it in our local variable
 				if (i == 0)


### PR DESCRIPTION
## Description

Issue #482 has been closed for some time, but its fix commit 9e871bf remains stuck in the `issue-477` branch.  This PR cherry-picks the fix so it can be released independently of that branch.

My app has been using a patched version of Insight (`main` plus this one commit) **in production** since September 2022.  I would like to stop maintaining a fork of Insight.Database and go back to official releases.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No

### Any other comment
<!-- Provide additional relevant info here. -->
(n/a)
