### PR TITLE
Implement OneToOne.GetHashCode() to fix a memory leak

### DIFF
--- a/Insight.Database.Core/Structure/OneToOne.cs
+++ b/Insight.Database.Core/Structure/OneToOne.cs
@@ -106,6 +106,15 @@ namespace Insight.Database
 		#endregion
 
 		#region Methods
+		/// <summary>
+		/// Returns the hash code for this mapping.
+		/// </summary>
+		/// <returns>The hash code for this mapping.</returns>
+		public override int GetHashCode()
+		{
+			return _hashCode;
+		}
+
 		/// <inheritdoc/>
 		public override bool Equals(IRecordReader other)
 		{


### PR DESCRIPTION
## Description
This PR fixes a memory leak that was happening in `Insight.Database.CodeGenerator.DbReaderDeserializer` caused by `GetHashCode` not being implemented in the `OneToOne` mapping class.  

There is an existing pre-calculated `_hashCode` field that looks appropriate for this class, but it was never exposed through the `GetHashCode` method.  This led to an issue where the static ConcurrentDictionary  `_deserializers` in DbReaderDeserializer that is caching the deserializers was not recognizing that a deserializer already exists for a particular reader when checking if it needs to add a new one, ultimately leading to new deserializers accumulating in that cache over time and never getting released.

## Checklist
Please make sure your pull request fulfills the following requirements:

- [x] Tests for any changes have been added (for bug fixes / features).
- [x] Docs have been added / updated (for bug fixes / features).

## Type
This pull request includes what type of changes?
<!-- please check the one that applies using an "x" -->

- [x] Bug.
- [ ] Feature.
- [ ] Code style update (formatting, local variables).
- [ ] Refactoring (no functional changes, no api changes).
- [ ] Documentation content changes.
- [ ] Other (please describe below).


## Breaking Changes
Does this pull request introduce any breaking changes?
<!-- please check the one that applies using an "x" -->

- [ ] Yes
- [x] No

### Any other comment
<!-- Provide additional relevant info here. -->
(n/a)
