### PR TITLE
NullRef issue when using Postgres BulkCopy

### DIFF
--- a/Insight.Tests.PostgreSQL/PostgreSQLTests.cs
+++ b/Insight.Tests.PostgreSQL/PostgreSQLTests.cs
@@ -849,7 +849,7 @@ namespace Insight.Tests.PostgreSQL
 		}
 		#endregion
 
-		#region BulkCopy NullRef issue
+		#region Issue 514
 
 		public class TestPOCO
 		{


### PR DESCRIPTION
As per issue #514, a small test added to `PostgreSQLTests.cs` to illustrate.


